### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,2 @@
 /** Return a `DataView` instance that uses the same memory as the provided `ArrayBuffer`, 8-bit typed array or `Buffer`. */
-declare function toDataView (data: ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray): DataView
-export = toDataView
+export default function toDataView (data: ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray): DataView

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function toDataView (data) {
+export default function toDataView (data) {
   if (data instanceof Int8Array || data instanceof Uint8Array || data instanceof Uint8ClampedArray) {
     return new DataView(data.buffer, data.byteOffset, data.byteLength)
   }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,16 @@
   "version": "1.1.0",
   "license": "MIT",
   "repository": "LinusU/to-data-view",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
     "test": "standard && node test && ts-readme-generator --check"
   },
   "devDependencies": {
-    "standard": "^14.3.1",
+    "standard": "^16.0.3",
     "ts-readme-generator": "^0.5.0"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ npm install --save to-data-view
 ## Usage
 
 ```js
-const toDataView = require('to-data-view')
+import toDataView from 'to-data-view'
 
 // This function will accept both `ArrayBuffer` and `Buffer` as input
 function awesomeParser (source) {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const toDataView = require('./')
+import assert from 'node:assert'
+import toDataView from './index.js'
 
 assert(toDataView(Buffer.from('test')) instanceof DataView)
 assert(toDataView(new ArrayBuffer(10)) instanceof DataView)


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`