### PR TITLE
fix: special scene `instanceof ArrayBuffer` does not hold

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ export default function toDataView (data) {
     return new DataView(data.buffer, data.byteOffset, data.byteLength)
   }
 
-  if (data instanceof ArrayBuffer) {
+  if (data instanceof ArrayBuffer || Object.prototype.toString.call(data) === '[object ArrayBuffer]') {
     return new DataView(data)
   }
 


### PR DESCRIPTION
In some scenarios, `data` is an ArrayBuffer instance, but it cannot satisfy `data instanceof ArrayBuffer`, see: https://github.com/jestjs/jest/issues/10786#issuecomment-735273296

Use `toString` to get the string of the `data` object for whether data is an ArrayBuffer.